### PR TITLE
Allow deserialization of nested structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- deserialization of nested structs ([#37](https://github.com/monero-rs/monero-epee-bin-serde/pull/37))
+- Deserialization of nested structs ([#37](https://github.com/monero-rs/monero-epee-bin-serde/pull/37)).
 
 ## [1.0.1] - 2021-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- deserialization of nested structs ([#37](https://github.com/monero-rs/monero-epee-bin-serde/pull/37))
+
 ## [1.0.1] - 2021-07-09
 
 ### Fixed

--- a/src/de.rs
+++ b/src/de.rs
@@ -479,6 +479,7 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
     where
         V: Visitor<'de>,
     {
+        self.read_expected_marker(MARKER_SINGLE_STRUCT)?;
         visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?)
     }
 
@@ -491,6 +492,7 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
     where
         V: Visitor<'de>,
     {
+        self.read_expected_marker(MARKER_SINGLE_STRUCT)?;
         visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,14 @@ where
         return Err(Error::missing_header_bytes());
     }
 
+    // Monero encodes markers after each key and before each value which
+    // means if the value is a struct the marker will need to be read.
+    //
+    // However the parent struct does not have any marker so we add it here.
+    // see: https://github.com/monero-rs/monero-epee-bin-serde/issues/36
+    //
+    let mut bytes = &[&[MARKER_SINGLE_STRUCT.to_byte()], bytes].concat()[..];
+
     let mut deserializer = Deserializer::new(&mut bytes);
 
     T::deserialize(&mut deserializer)

--- a/tests/monerod_p2p.rs
+++ b/tests/monerod_p2p.rs
@@ -5,7 +5,7 @@ use serde_with::serde_as;
 use serde_with::TryFromInto;
 use std::fmt::Debug;
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct BasicNodeData {
     pub my_port: u32,
     pub network_id: [u8; 16],
@@ -18,7 +18,7 @@ pub struct BasicNodeData {
 }
 
 #[serde_as]
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct CoreSyncData {
     pub cumulative_difficulty: u64,
     pub cumulative_difficulty_top64: u64,
@@ -29,7 +29,7 @@ pub struct CoreSyncData {
     pub top_version: u8,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct HandshakeR {
     pub node_data: BasicNodeData,
     pub payload_data: CoreSyncData,
@@ -55,9 +55,9 @@ fn received_handshake() {
             current_height: 2755066,
             cumulative_difficulty: 237190611121688889,
             cumulative_difficulty_top64: 0,
-            top_id: monero::Hash {
-                0: hex!("6cc497b230ba57a95edb370be8d6870c94e0992937c89b1def3a4cb7726d37ad"),
-            },
+            top_id: monero::Hash(hex!(
+                "6cc497b230ba57a95edb370be8d6870c94e0992937c89b1def3a4cb7726d37ad"
+            )),
             top_version: 16,
             pruning_seed: 384,
         },

--- a/tests/monerod_p2p.rs
+++ b/tests/monerod_p2p.rs
@@ -1,0 +1,68 @@
+use hex_literal::hex;
+use monero_epee_bin_serde::{from_bytes, to_bytes};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use serde_with::TryFromInto;
+use std::fmt::Debug;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct BasicNodeData {
+    pub my_port: u32,
+    pub network_id: [u8; 16],
+    pub peer_id: u64,
+    pub support_flags: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpc_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rpc_credits_per_hash: Option<u32>,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct CoreSyncData {
+    pub cumulative_difficulty: u64,
+    pub cumulative_difficulty_top64: u64,
+    pub current_height: u64,
+    pub pruning_seed: u32,
+    #[serde_as(as = "TryFromInto<[u8; 32]>")]
+    pub top_id: monero::Hash,
+    pub top_version: u8,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct HandshakeR {
+    pub node_data: BasicNodeData,
+    pub payload_data: CoreSyncData,
+}
+
+#[test]
+fn received_handshake() {
+    let bytes = hex!("01110101010102010108096e6f64655f646174610c10076d795f706f727406a04600000a6e6574776f726b5f69640a401230f171610441611731008216a1a11007706565725f6964053eb3c096c4471c340d737570706f72745f666c61677306010000000c7061796c6f61645f646174610c181563756d756c61746976655f646966666963756c7479053951f7a79aab4a031b63756d756c61746976655f646966666963756c74795f746f7036340500000000000000000e63757272656e745f68656967687405fa092a00000000000c7072756e696e675f73656564068001000006746f705f69640a806cc497b230ba57a95edb370be8d6870c94e0992937c89b1def3a4cb7726d37ad0b746f705f76657273696f6e0810");
+    let decoded_handshake = from_bytes::<HandshakeR, _>(bytes).unwrap();
+
+    let handshake = HandshakeR {
+        node_data: BasicNodeData {
+            network_id: [
+                18, 48, 241, 113, 97, 4, 65, 97, 23, 49, 0, 130, 22, 161, 161, 16,
+            ],
+            my_port: 18080,
+            rpc_port: None,
+            rpc_credits_per_hash: None,
+            peer_id: 3754955098988524350,
+            support_flags: 1,
+        },
+        payload_data: CoreSyncData {
+            current_height: 2755066,
+            cumulative_difficulty: 237190611121688889,
+            cumulative_difficulty_top64: 0,
+            top_id: monero::Hash {
+                0: hex!("6cc497b230ba57a95edb370be8d6870c94e0992937c89b1def3a4cb7726d37ad"),
+            },
+            top_version: 16,
+            pruning_seed: 384,
+        },
+    };
+    assert_eq!(decoded_handshake, handshake);
+    let encoded_handshake = to_bytes(&handshake).unwrap();
+    assert_eq!(encoded_handshake, bytes);
+}


### PR DESCRIPTION
fixes #36 

I have made it so when de-serializing a struct (or map) it will read the marker, however it will do this even for the parent struct so I had to make it add a marker before the data is de-serialized.