### PR TITLE
chore: fix ci badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/github/workflow/status/comit-network/monero-epee-bin-serde/CI/main)](https://github.com/comit-network/monero-epee-bin-serde/actions/workflows/ci.yml)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/comit-network/monero-epee-bin-serde/ci.yml?branch=main)](https://github.com/comit-network/monero-epee-bin-serde/actions/workflows/ci.yml)
 [![unsafe forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg)](https://github.com/rust-secure-code/safety-dance/)
 [![Crates.io](https://img.shields.io/crates/v/monero-epee-bin-serde.svg)](https://crates.io/crates/monero-epee-bin-serde)
 [![Documentation](https://docs.rs/monero-epee-bin-serde/badge.svg)](https://docs.rs/monero-epee-bin-serde)


### PR DESCRIPTION
New shields.io URL for displaying CI status badge.