### PR TITLE
Change most of the Deserializer to use `forward_to_deserialize_any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated Rust version to 2021 and bumped MSRV to 1.63 ([#52](https://github.com/monero-rs/monero-epee-bin-serde/pull/37)).
+- Updated Rust version to 2021 and bumped MSRV to 1.63 ([#52](https://github.com/monero-rs/monero-epee-bin-serde/pull/52)).
 
 ### Fixed
 
+- No longer panic on unknown fields ([#46](https://github.com/monero-rs/monero-epee-bin-serde/pull/46))
 - Deserialization of nested structs ([#37](https://github.com/monero-rs/monero-epee-bin-serde/pull/37)).
 
 ## [1.0.1] - 2021-07-09

--- a/src/de.rs
+++ b/src/de.rs
@@ -15,7 +15,7 @@ pub struct Deserializer<'b> {
 
 impl<'b> Deserializer<'b> {
     pub fn new(buffer: &'b mut dyn io::BufRead) -> Self {
-        Self { 
+        Self {
             buffer,
             read_header: false,
         }
@@ -328,11 +328,7 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
         Err(Error::unit_is_not_supported())
     }
 
-    fn deserialize_unit_struct<V>(
-        self,
-        _: &'static str,
-        _: V,
-    ) -> Result<<V as Visitor<'de>>::Value>
+    fn deserialize_unit_struct<V>(self, _: &'static str, _: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {

--- a/src/de.rs
+++ b/src/de.rs
@@ -2,7 +2,7 @@ use crate::{
     varint, Error, Marker, Result, MARKER_SINGLE_BOOL, MARKER_SINGLE_F64, MARKER_SINGLE_I16,
     MARKER_SINGLE_I32, MARKER_SINGLE_I64, MARKER_SINGLE_I8, MARKER_SINGLE_STRING,
     MARKER_SINGLE_STRUCT, MARKER_SINGLE_U16, MARKER_SINGLE_U32, MARKER_SINGLE_U64,
-    MARKER_SINGLE_U8, MARKER_U8,
+    MARKER_SINGLE_U8, MARKER_U8, MAX_STRING_LEN_POSSIBLE,
 };
 use byteorder::{LittleEndian, ReadBytesExt};
 use serde::de::Visitor;
@@ -54,11 +54,13 @@ impl<'b> Deserializer<'b> {
         Ok(value)
     }
 
-    fn read_varint_string(&mut self) -> Result<String> {
-        let string_length = self.read_varint()?;
-        let string = self.read_string(string_length)?;
-
-        Ok(string)
+    fn read_varint_marked_string(&mut self) -> Result<Vec<u8>> {
+        let length = self.read_varint()?;
+        if length > MAX_STRING_LEN_POSSIBLE {
+            return Err(Error::length_exceeded_max_size());
+        }
+        let buf = self.read_bytes(length)?;
+        Ok(buf)
     }
 
     fn read_bool(&mut self) -> Result<bool> {
@@ -102,7 +104,7 @@ impl<'b> Deserializer<'b> {
             MARKER_SINGLE_U16 => visitor.visit_u16(self.buffer.read_u16::<LittleEndian>()?),
             MARKER_SINGLE_U8 => visitor.visit_u8(self.buffer.read_u8()?),
             MARKER_SINGLE_F64 => visitor.visit_f64(self.buffer.read_f64::<LittleEndian>()?),
-            MARKER_SINGLE_STRING => visitor.visit_string(self.read_varint_string()?),
+            MARKER_SINGLE_STRING => visitor.visit_byte_buf(self.read_varint_marked_string()?),
             MARKER_SINGLE_BOOL => visitor.visit_bool(self.read_bool()?),
             MARKER_SINGLE_STRUCT => visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?),
             _ => Err(Error::unknown_marker(marker)),
@@ -268,83 +270,22 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
     {
         if !self.read_header {
             self.read_header = true;
+            visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?)
+        } else {
+            if !self.read_header {
+            self.read_header = true;
             return visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?);
         }
 
         let marker = self.read_marker()?;
-        self.dispatch_based_on_marker(marker, visitor)
+            self.dispatch_based_on_marker(marker, visitor)
+        }
     }
 
-    fn deserialize_bool<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_BOOL)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_BOOL, visitor)
-    }
-
-    fn deserialize_i8<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_I8)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_I8, visitor)
-    }
-
-    fn deserialize_i16<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_I16)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_I16, visitor)
-    }
-
-    fn deserialize_i32<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_I32)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_I32, visitor)
-    }
-
-    fn deserialize_i64<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_I64)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_I64, visitor)
-    }
-
-    fn deserialize_u8<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_U8)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_U8, visitor)
-    }
-
-    fn deserialize_u16<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_U16)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_U16, visitor)
-    }
-
-    fn deserialize_u32<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_U32)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_U32, visitor)
-    }
-
-    fn deserialize_u64<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_U64)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_U64, visitor)
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f64
+        bytes byte_buf newtype_struct seq map struct
+        identifier ignored_any
     }
 
     fn deserialize_f32<V>(self, _: V) -> Result<<V as Visitor<'de>>::Value>
@@ -352,14 +293,6 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
         V: Visitor<'de>,
     {
         Err(Error::f32_is_not_supported())
-    }
-
-    fn deserialize_f64<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_F64)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_U64, visitor)
     }
 
     fn deserialize_char<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
@@ -370,37 +303,20 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
         visitor.visit_char(self.buffer.read_u8()? as char)
     }
 
-    fn deserialize_str<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
+    fn deserialize_str<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         self.deserialize_string(visitor)
     }
 
-    fn deserialize_string<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
+    fn deserialize_string<V>(self, visitor: V) -> Result<V::Value>
     where
         V: Visitor<'de>,
     {
         self.read_expected_marker(MARKER_SINGLE_STRING)?;
-        self.dispatch_based_on_marker(MARKER_SINGLE_STRING, visitor)
-    }
-
-    fn deserialize_bytes<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_byte_buf(visitor)
-    }
-
-    fn deserialize_byte_buf<V>(self, v: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.read_expected_marker(MARKER_SINGLE_STRING)?;
-        let length = self.read_varint()?;
-        let buffer = self.read_bytes(length)?;
-
-        v.visit_byte_buf(buffer)
+        let potential_str = self.read_varint_marked_string()?;
+        visitor.visit_string(String::from_utf8(potential_str)?)
     }
 
     fn deserialize_option<V>(self, _: V) -> Result<<V as Visitor<'de>>::Value>
@@ -420,31 +336,12 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
     fn deserialize_unit_struct<V>(
         self,
         _: &'static str,
-        visitor: V,
+        _: V,
     ) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        self.deserialize_unit(visitor)
-    }
-
-    fn deserialize_newtype_struct<V>(
-        self,
-        _: &'static str,
-        visitor: V,
-    ) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_any(visitor)
-    }
-
-    fn deserialize_seq<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        let marker = self.read_marker()?;
-        self.dispatch_based_on_marker(marker, visitor)
+        Err(Error::unit_is_not_supported())
     }
 
     fn deserialize_tuple<V>(
@@ -484,25 +381,6 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
         Err(Error::tuple_structs_are_not_supported())
     }
 
-    fn deserialize_map<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_any(visitor)
-    }
-
-    fn deserialize_struct<V>(
-        self,
-        _: &'static str,
-        _: &'static [&'static str],
-        visitor: V,
-    ) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        self.deserialize_any(visitor)
-    }
-
     fn deserialize_enum<V>(
         self,
         _: &'static str,
@@ -513,19 +391,5 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
         V: Visitor<'de>,
     {
         Err(Error::enums_are_not_supported())
-    }
-
-    fn deserialize_identifier<V>(self, _: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        todo!("Unsure what should be done here?")
-    }
-
-    fn deserialize_ignored_any<V>(self, _: V) -> Result<<V as Visitor<'de>>::Value>
-    where
-        V: Visitor<'de>,
-    {
-        todo!("Unsure what should be done here?")
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -10,11 +10,15 @@ use std::io;
 
 pub struct Deserializer<'b> {
     buffer: &'b mut dyn io::BufRead,
+    read_header: bool,
 }
 
 impl<'b> Deserializer<'b> {
     pub fn new(buffer: &'b mut dyn io::BufRead) -> Self {
-        Self { buffer }
+        Self { 
+            buffer,
+            read_header: false,
+        }
     }
 }
 
@@ -266,16 +270,11 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
     {
         if !self.read_header {
             self.read_header = true;
-            visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?)
-        } else {
-            if !self.read_header {
-            self.read_header = true;
             return visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?);
         }
 
         let marker = self.read_marker()?;
-            self.dispatch_based_on_marker(marker, visitor)
-        }
+        self.dispatch_based_on_marker(marker, visitor)
     }
 
     serde::forward_to_deserialize_any! {

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,6 +17,7 @@ enum Kind {
     NoLength,
     UnexpectedBool { value: u8 },
     LengthMismatch { expected: usize, found: usize },
+    LengthTooLong,
     MissingHeaderBytes,
     InvalidFieldName(FromUtf8Error),
     UnknownMarker { value: Marker },
@@ -137,6 +138,12 @@ impl Error {
             kind: Kind::OptionsAreNotSupported,
         }
     }
+
+    pub(crate) fn length_exceeded_max_size() -> Error {
+        Self {
+            kind: Kind::LengthTooLong,
+        }
+    }
 }
 
 impl fmt::Display for Error {
@@ -165,6 +172,7 @@ impl fmt::Display for Error {
                 "Length mismatch, expected {} elements but found {}",
                 expected, found
             ),
+            Kind::LengthTooLong => write!(f, "Length of field exceeded maximum size"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,14 +65,6 @@ where
         return Err(Error::missing_header_bytes());
     }
 
-    // Monero encodes markers after each key and before each value which
-    // means if the value is a struct the marker will need to be read.
-    //
-    // However the parent struct does not have any marker so we add it here.
-    // see: https://github.com/monero-rs/monero-epee-bin-serde/issues/36
-    //
-    let mut bytes = &[&[MARKER_SINGLE_STRUCT.to_byte()], bytes].concat()[..];
-
     let mut deserializer = Deserializer::new(&mut bytes);
 
     T::deserialize(&mut deserializer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,14 @@ where
         return Err(Error::missing_header_bytes());
     }
 
+    // Monero encodes markers after each key and before each value which
+    // means if the value is a struct the marker will need to be read.
+    //
+    // However the parent struct does not have any marker so we add it here.
+    // see: https://github.com/monero-rs/monero-epee-bin-serde/issues/36
+    //
+    let mut bytes = &[&[MARKER_SINGLE_STRUCT.to_byte()], bytes].concat()[..];
+
     let mut deserializer = Deserializer::new(&mut bytes);
 
     T::deserialize(&mut deserializer)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// Header that needs to be at the beginning of every binary blob that follows
 /// this binary serialization format.
 const HEADER: &[u8] = b"\x01\x11\x01\x01\x01\x01\x02\x01\x01";
+/// The maximum length a byte array (marked as a string) can be.
+const MAX_STRING_LEN_POSSIBLE: usize = 2000000000;
 
 /// Serialize the given object to binary.
 ///


### PR DESCRIPTION
fixes #27 

~~This also changes my old commit fixing structs with embedded structs to use a different method. A bool `read_header` instead of putting a struct marker at the front of the array of data.~~

This also fixes the panics on incomplete structs, just forwarding to forward_to_deserialize_any.

I could have removed more of the de-serialize but I feel the explicit errors on unsupported types may be helpful.

I have also changed how the Deserializer handles string markers, this is because epee marks byte arrays as strings so if someone sends a bytes array in a field we don't have this will get forwarded to deserialize_any which will then fail if the byte array isn't an actual string.

@thomaseizinger 