### PR TITLE
Don't prepend marker for deserialization of root struct

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -15,7 +15,10 @@ pub struct Deserializer<'b> {
 
 impl<'b> Deserializer<'b> {
     pub fn new(buffer: &'b mut dyn io::BufRead) -> Self {
-        Self { buffer, read_header: false }
+        Self {
+            buffer,
+            read_header: false,
+        }
     }
 }
 
@@ -485,8 +488,7 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
     where
         V: Visitor<'de>,
     {
-        self.read_expected_marker(MARKER_SINGLE_STRUCT)?;
-        visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?)
+        self.deserialize_any(visitor)
     }
 
     fn deserialize_struct<V>(
@@ -498,8 +500,7 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
     where
         V: Visitor<'de>,
     {
-        self.read_expected_marker(MARKER_SINGLE_STRUCT)?;
-        visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?)
+        self.deserialize_any(visitor)
     }
 
     fn deserialize_enum<V>(

--- a/src/de.rs
+++ b/src/de.rs
@@ -268,9 +268,9 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
     {
         if !self.read_header {
             self.read_header = true;
-            return visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?)
+            return visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?);
         }
-        
+
         let marker = self.read_marker()?;
         self.dispatch_based_on_marker(marker, visitor)
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -268,11 +268,11 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
     {
         if !self.read_header {
             self.read_header = true;
-            visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?)
-        } else {
-            let marker = self.read_marker()?;
-            self.dispatch_based_on_marker(marker, visitor)
+            return visitor.visit_map(MapAccess::with_varint_encoded_fields(self)?)
         }
+        
+        let marker = self.read_marker()?;
+        self.dispatch_based_on_marker(marker, visitor)
     }
 
     fn deserialize_bool<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,14 +63,6 @@ where
         return Err(Error::missing_header_bytes());
     }
 
-    // Monero encodes markers after each key and before each value which
-    // means if the value is a struct the marker will need to be read.
-    //
-    // However the parent struct does not have any marker so we add it here.
-    // see: https://github.com/monero-rs/monero-epee-bin-serde/issues/36
-    //
-    let mut bytes = &[&[MARKER_SINGLE_STRUCT.to_byte()], bytes].concat()[..];
-
     let mut deserializer = Deserializer::new(&mut bytes);
 
     T::deserialize(&mut deserializer)


### PR DESCRIPTION
I didn't like the old method, this one is better 