### PR TITLE
allow optional values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Allow optional values ([#59](https://github.com/monero-rs/monero-epee-bin-serde/pull/59))
 - Updated Rust version to 2021 and bumped MSRV to 1.63 ([#52](https://github.com/monero-rs/monero-epee-bin-serde/pull/52)).
 
 ### Fixed

--- a/src/de.rs
+++ b/src/de.rs
@@ -314,11 +314,12 @@ impl<'de, 'a, 'b> serde::Deserializer<'de> for &'a mut Deserializer<'b> {
         visitor.visit_string(String::from_utf8(potential_str)?)
     }
 
-    fn deserialize_option<V>(self, _: V) -> Result<<V as Visitor<'de>>::Value>
+    fn deserialize_option<V>(self, visitor: V) -> Result<<V as Visitor<'de>>::Value>
     where
         V: Visitor<'de>,
     {
-        Err(Error::options_are_not_supported())
+        // If the field is present then it's always a Some(T) in epee
+        visitor.visit_some(self)
     }
 
     fn deserialize_unit<V>(self, _: V) -> Result<<V as Visitor<'de>>::Value>

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ enum Kind {
     Custom(String),
     RootMustBeStruct { value: Marker },
     F32IsNotSupported,
-    OptionsAreNotSupported,
+    NoneCanNotBeSerialized,
     UnitIsNotSupported,
     EnumsAreNotSupported,
     TuplesOfTypeAreNotSupported { marker: Marker },
@@ -133,9 +133,9 @@ impl Error {
         }
     }
 
-    pub(crate) fn options_are_not_supported() -> Error {
+    pub(crate) fn none_can_not_be_serialized() -> Error {
         Self {
-            kind: Kind::OptionsAreNotSupported,
+            kind: Kind::NoneCanNotBeSerialized,
         }
     }
 
@@ -160,7 +160,7 @@ impl fmt::Display for Error {
                 write!(f, "Root element must be a struct but got {}", value)
             }
             Kind::F32IsNotSupported => write!(f, "Type f32 is not supported"),
-            Kind::OptionsAreNotSupported => write!(f, "Options are not supported"),
+            Kind::NoneCanNotBeSerialized => write!(f, "Optional fields must be wrapped in #[serde(skip_serializing_if = \"Option::is_none\")]"),
             Kind::UnitIsNotSupported => write!(f, "Unit type is not supported"),
             Kind::EnumsAreNotSupported => write!(f, "Enums are not supported"),
             Kind::TuplesOfTypeAreNotSupported { marker } => {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -173,14 +173,14 @@ impl<'a, 'b> serde::Serializer for &'a mut Serializer<'b> {
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
-        Err(Error::options_are_not_supported())
+        Err(Error::none_can_not_be_serialized())
     }
 
-    fn serialize_some<T: ?Sized>(self, _: &T) -> Result<Self::Ok>
+    fn serialize_some<T: ?Sized>(self, v: &T) -> Result<Self::Ok>
     where
         T: Serialize,
     {
-        Err(Error::options_are_not_supported())
+        v.serialize(self)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {

--- a/tests/other.rs
+++ b/tests/other.rs
@@ -2,13 +2,35 @@ use monero_epee_bin_serde::{from_bytes, to_bytes};
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Deserialize, Serialize, PartialEq, Debug)]
-struct TestStruct {
+struct TestSeq {
     seq: Vec<u32>,
 }
 
 #[test]
 fn empty_sequence() {
-    let obj = TestStruct::default();
+    let obj = TestSeq::default();
     let data = to_bytes(&obj).unwrap();
     assert_eq!(obj, from_bytes(data).unwrap());
+}
+
+#[derive(Default, Deserialize, Serialize, PartialEq, Debug)]
+struct TestOptional {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    val: Option<u8>,
+}
+
+#[test]
+fn optional_val_present() {
+    let val = TestOptional { val: Some(1) };
+    let buf = to_bytes(&val).unwrap();
+    let val2 = from_bytes(&buf).unwrap();
+    assert_eq!(val, val2);
+}
+
+#[test]
+fn optional_val_not_present() {
+    let val = TestOptional::default();
+    let buf = to_bytes(&val).unwrap();
+    let val2 = from_bytes(&buf).unwrap();
+    assert_eq!(val, val2);
 }

--- a/tests/other.rs
+++ b/tests/other.rs
@@ -23,7 +23,7 @@ struct TestOptional {
 fn optional_val_present() {
     let val = TestOptional { val: Some(1) };
     let buf = to_bytes(&val).unwrap();
-    let val2 = from_bytes(&buf).unwrap();
+    let val2 = from_bytes(buf).unwrap();
     assert_eq!(val, val2);
 }
 
@@ -31,6 +31,6 @@ fn optional_val_present() {
 fn optional_val_not_present() {
     let val = TestOptional::default();
     let buf = to_bytes(&val).unwrap();
-    let val2 = from_bytes(&buf).unwrap();
+    let val2 = from_bytes(buf).unwrap();
     assert_eq!(val, val2);
 }


### PR DESCRIPTION
they must have the #[serde(skip_serializing_if = "Option::is_none")] attribute.